### PR TITLE
Sort tutorial keywords into types with a keyword vocabulary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,5 @@ repos:
       - id: check-json
       - id: check-yaml
         args: ["--allow-multiple-documents"]
+      - id: sort-simple-yaml
+        files: keywords\.yaml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-toml
+      - id: check-json
+      - id: check-yaml
+        args: ["--allow-multiple-documents"]

--- a/astropylibrarian/algolia/records.py
+++ b/astropylibrarian/algolia/records.py
@@ -5,10 +5,12 @@
 __all__ = ['TutorialSectionRecord']
 
 from base64 import b64encode
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import datetime
-from typing import TYPE_CHECKING, Dict, Any
+from typing import TYPE_CHECKING, Dict, Any, List
 from urllib.parse import urlparse, urlunparse
+
+from astropylibrarian.keywords import KeywordDb
 
 if TYPE_CHECKING:
     from astropylibrarian.reducers.utils import Section
@@ -29,6 +31,9 @@ class TutorialSectionRecord:
     """The reduced tutorial page that this record is associated with
     (`astropylibrarian.reducers.tutorial.ReducedTutorial`).
     """
+
+    keyworddb: KeywordDb = field(default_factory=KeywordDb.load)
+    """Keyword database."""
 
     @property
     def object_id(self) -> str:
@@ -62,6 +67,30 @@ class TutorialSectionRecord:
         ))
 
     @property
+    def astropy_package_keywords(self) -> List[str]:
+        """The list of "Astropy package" keywords."""
+        return self.keyworddb.get_astropy_package_keywords(
+            self.tutorial.keywords)
+
+    @property
+    def python_package_keywords(self) -> List[str]:
+        """The list of "Python package" keywords."""
+        return self.keyworddb.get_python_package_keywords(
+            self.tutorial.keywords)
+
+    @property
+    def task_keywords(self) -> List[str]:
+        """The list of "task" keywords."""
+        return self.keyworddb.get_task_keywords(
+            self.tutorial.keywords)
+
+    @property
+    def science_keywords(self) -> List[str]:
+        """The list of "science" keywords."""
+        return self.keyworddb.get_science_keywords(
+            self.tutorial.keywords)
+
+    @property
     def data(self) -> Dict[str, Any]:
         """The JSON-encodable record, ready for indexing by Algolia.
         """
@@ -73,7 +102,10 @@ class TutorialSectionRecord:
             'importance': self.section.header_level,
             'contentType': 'tutorial',
             'authors': self.tutorial.authors,
-            'keywords': self.tutorial.keywords,
+            'astropy_package_keywords': self.astropy_package_keywords,
+            'python_package_keywords': self.python_package_keywords,
+            'task_keywords': self.task_keywords,
+            'science_keywords': self.science_keywords,
             'dateIndexed': f'{datetime.datetime.now().isoformat()}Z'
         }
         for i, heading in enumerate(self.section.headings):

--- a/astropylibrarian/algolia/records.py
+++ b/astropylibrarian/algolia/records.py
@@ -69,26 +69,27 @@ class TutorialSectionRecord:
     @property
     def astropy_package_keywords(self) -> List[str]:
         """The list of "Astropy package" keywords."""
-        return self.keyworddb.get_astropy_package_keywords(
-            self.tutorial.keywords)
+        return self.keyworddb.filter_keywords(
+            self.tutorial.keywords, 'astropy_package'
+        )
 
     @property
     def python_package_keywords(self) -> List[str]:
         """The list of "Python package" keywords."""
-        return self.keyworddb.get_python_package_keywords(
-            self.tutorial.keywords)
+        return self.keyworddb.filter_keywords(
+            self.tutorial.keywords, 'python_package')
 
     @property
     def task_keywords(self) -> List[str]:
         """The list of "task" keywords."""
-        return self.keyworddb.get_task_keywords(
-            self.tutorial.keywords)
+        return self.keyworddb.filter_keywords(
+            self.tutorial.keywords, 'task')
 
     @property
     def science_keywords(self) -> List[str]:
         """The list of "science" keywords."""
-        return self.keyworddb.get_science_keywords(
-            self.tutorial.keywords)
+        return self.keyworddb.filter_keywords(
+            self.tutorial.keywords, 'science')
 
     @property
     def data(self) -> Dict[str, Any]:

--- a/astropylibrarian/data/keywords.yaml
+++ b/astropylibrarian/data/keywords.yaml
@@ -1,23 +1,53 @@
 astropy_package:
   - astroquery
-  - coordinates
+  - coordinates:
+      - astropy.coordinates
   - astroplan
   - reproject
-  - table
+  - table:
+      - astropy.table
   - spectral cube
   - aplpy
   - imexam
   - specutils
   - photutils
-  - wcs
-  - units
-  - time
+  - wcs:
+      - astropy.wcs
+  - units:
+      - astropy.units
+  - time:
+      - astropy.time
   - synphot
-  - dust extinction
-  - modeling
-  - convolution
+  - dust_extinction:
+      - dust extinction
+  - modeling:
+      - astropy.modelling
+  - convolution:
+      - astropy.convolution
   - gala
   - vo conesearch
+  - constants:
+      - astropy.constants
+  - nddata:
+      - astropy.nddata
+  - timeseries:
+      - astropy.timeseries
+  - uncertainty:
+      - astropy.uncertainty
+  - io:
+      - astropy.io
+  - samp:
+      - astropy.samp
+  - cosmology:
+      - astropy.cosmology
+  - visualization:
+      - astropy.visualization
+  - stats:
+      - astropy.stats
+  - config:
+      - astropy.config
+  - utils:
+      - astropy.utils
 
 python_package:
   - matplotlib
@@ -34,11 +64,11 @@ task:
   - file input/output
   - histogram
   - error bars
-  - oop
+  - object-oriented programming:
+      - oop
   - scatter plots
   - spectroscopy
   - time series
-  - units
   - vizier
   - photometry
   - colorbar

--- a/astropylibrarian/data/keywords.yaml
+++ b/astropylibrarian/data/keywords.yaml
@@ -1,93 +1,93 @@
 astropy_package:
-  - astroquery
-  - coordinates:
-      - astropy.coordinates
-  - astroplan
-  - reproject
-  - table:
-      - astropy.table
-  - spectral cube
   - aplpy
-  - imexam
-  - specutils
-  - photutils
-  - wcs:
-      - astropy.wcs
-  - units:
-      - astropy.units
-  - time:
-      - astropy.time
-  - synphot
-  - dust_extinction:
-      - dust extinction
-  - modeling:
-      - astropy.modelling
+  - astroplan
+  - astroquery
+  - config:
+      - astropy.config
   - convolution:
       - astropy.convolution
-  - gala
-  - vo conesearch
   - constants:
       - astropy.constants
+  - coordinates:
+      - astropy.coordinates
+  - cosmology:
+      - astropy.cosmology
+  - dust_extinction:
+      - dust extinction
+  - gala
+  - imexam
+  - io:
+      - astropy.io
+  - modeling:
+      - astropy.modeling
   - nddata:
       - astropy.nddata
+  - photutils
+  - reproject
+  - samp:
+      - astropy.samp
+  - spectral cube
+  - specutils
+  - stats:
+      - astropy.stats
+  - synphot
+  - table:
+      - astropy.table
+  - time:
+      - astropy.time
   - timeseries:
       - astropy.timeseries
   - uncertainty:
       - astropy.uncertainty
-  - io:
-      - astropy.io
-  - samp:
-      - astropy.samp
-  - cosmology:
-      - astropy.cosmology
-  - visualization:
-      - astropy.visualization
-  - stats:
-      - astropy.stats
-  - config:
-      - astropy.config
+  - units:
+      - astropy.units
   - utils:
       - astropy.utils
+  - visualization:
+      - astropy.visualization
+  - vo conesearch
+  - wcs:
+      - astropy.wcs
 
 python_package:
   - matplotlib
   - numpy
   - scipy
 
+science:
+  - astrodynamics
+  - astrometry
+  - astrostatistics
+  - extinction
+  - galactic astronomy
+  - galaxy dynamics
+  - observational astronomy
+  - physics
+  - polarimetry
+  - radio astronomy
+  - stellar evolution
+  - stellar photometry
+  - stellar physics
+  - x-ray astronomy
+
 task:
+  - colorbar
   - contour plots
   - data cubes
+  - error bars
+  - file input/output
   - fits
+  - histogram
   - image analysis
   - image manipulation
+  - latex
   - model fitting
-  - file input/output
-  - histogram
-  - error bars
+  - modular code
   - object-oriented programming:
       - oop
+  - photometry
   - scatter plots
+  - simbad
   - spectroscopy
   - time series
   - vizier
-  - photometry
-  - colorbar
-  - latex
-  - modular code
-  - simbad
-
-science:
-  - astrodynamics
-  - stellar photometry
-  - stellar physics
-  - radio astronomy
-  - astrostatistics
-  - x-ray astronomy
-  - galactic astronomy
-  - galaxy dynamics
-  - stellar evolution
-  - physics
-  - observational astronomy
-  - astrometry
-  - extinction
-  - polarimetry

--- a/astropylibrarian/data/keywords.yaml
+++ b/astropylibrarian/data/keywords.yaml
@@ -1,0 +1,63 @@
+astropy_package:
+  - astroquery
+  - coordinates
+  - astroplan
+  - reproject
+  - table
+  - spectral cube
+  - aplpy
+  - imexam
+  - specutils
+  - photutils
+  - wcs
+  - units
+  - time
+  - synphot
+  - dust extinction
+  - modeling
+  - convolution
+  - gala
+  - vo conesearch
+
+python_package:
+  - matplotlib
+  - numpy
+  - scipy
+
+task:
+  - contour plots
+  - data cubes
+  - FITS
+  - image analysis
+  - image manipulation
+  - model fitting
+  - file input/output
+  - histogram
+  - error bars
+  - OOP
+  - scatter plots
+  - spectroscopy
+  - time series
+  - units
+  - Vizier
+  - photometry
+  - colorbar
+  - LaTeX
+  - modular code
+  - Simbad
+
+science:
+  - astrodynamics
+  - stellar photometry
+  - stellar physics
+  - radio astronomy
+  - astrostatistics
+  - x-ray astronomy
+  - galactic astronomy
+  - galaxy dynamics
+  - stellar evolution
+  - physics
+  - observational astronomy
+  - astrometry
+  - extinction
+  - polarimetry

--- a/astropylibrarian/data/keywords.yaml
+++ b/astropylibrarian/data/keywords.yaml
@@ -27,24 +27,24 @@ python_package:
 task:
   - contour plots
   - data cubes
-  - FITS
+  - fits
   - image analysis
   - image manipulation
   - model fitting
   - file input/output
   - histogram
   - error bars
-  - OOP
+  - oop
   - scatter plots
   - spectroscopy
   - time series
   - units
-  - Vizier
+  - vizier
   - photometry
   - colorbar
-  - LaTeX
+  - latex
   - modular code
-  - Simbad
+  - simbad
 
 science:
   - astrodynamics

--- a/astropylibrarian/keywords.py
+++ b/astropylibrarian/keywords.py
@@ -1,0 +1,146 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Standardized Learn Astropy keywords."""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+KeywordTable = Dict[str, List[str]]
+"""Keyword table data type.
+
+The canonical keyword is the key, and alternative forms are strings in the
+list.
+"""
+
+
+class KeywordDb:
+    """A database of Astropy keywords and sorter of keyword types.
+
+    Parameters
+    ----------
+    astropy_package : `KeywordTable`
+        Keywords in the "Astropy package" group.
+    python_package : `KeywordTable`
+        Keywords in the "Python package" group.
+    task : `KeywordTable`
+        Keywords in the "task" group.
+    science : `KeywordTable`
+        Keywords in the "science" group.
+    """
+
+    def __init__(
+        self, *, astropy_package: KeywordTable,
+        python_package: KeywordTable, task: KeywordTable,
+        science: KeywordTable
+    ) -> None:
+        self._astropy_package_keywords = astropy_package
+        self._python_package_keywords = python_package
+        self._task_keywords = task
+        self._science_keywords = science
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> 'KeywordDb':
+        """Load a KeywordDB from a YAML file.
+
+        Parameters
+        ----------
+        path : `pathlib.Path`, optional
+            Path to the YAML-formatted keyword database file. Leave as `None`
+            to use the built-in keyword database.
+
+        Returns
+        -------
+        KeywordDb
+            A keyword database instance.
+        """
+        if path is None:
+            path = Path(__file__).parent / 'data' / 'keywords.yaml'
+
+        db = yaml.safe_load(path.read_text())
+
+        astropy_package_keywords = cls._load_keyword_table(
+            db['astropy_package'])
+        python_package_keywords = cls._load_keyword_table(
+            db['python_package'])
+        task_keywords = cls._load_keyword_table(
+            db['task'])
+        science_keywords = cls._load_keyword_table(
+            db['science'])
+
+        return cls(
+            astropy_package=astropy_package_keywords,
+            python_package=python_package_keywords,
+            task=task_keywords,
+            science=science_keywords
+        )
+
+    @staticmethod
+    def _load_keyword_table(group) -> KeywordTable:
+        keywords = {}
+        for keyword_item in group:
+            if isinstance(keyword_item, dict):
+                keyword = list(keyword_item.keys())[0]
+                alternatives = keyword_item[keyword]
+            elif isinstance(keyword_item, str):
+                keyword = keyword_item
+                alternatives = list()
+            keywords[keyword] = alternatives
+        return keywords
+
+    def get_astropy_package_keywords(
+            self, input_keywords: List[str]) -> List[str]:
+        """Get the list of "Astropy package" type keywords from an input list
+        of keywords that might include other type of keywords and alternate
+        forms of keywords.
+        """
+        return self._get_keywords_in_table(
+            table=self._astropy_package_keywords,
+            input_keywords=input_keywords)
+
+    def get_python_package_keywords(
+            self, input_keywords: List[str]) -> List[str]:
+        """Get the list of "Python package" type keywords from an input list
+        of keywords that might include other type of keywords and alternate
+        forms of keywords.
+        """
+        return self._get_keywords_in_table(
+            table=self._python_package_keywords,
+            input_keywords=input_keywords)
+
+    def get_task_keywords(
+            self, input_keywords: List[str]) -> List[str]:
+        """Get the list of "task" type keywords from an input list
+        of keywords that might include other type of keywords and alternate
+        forms of keywords.
+        """
+        return self._get_keywords_in_table(
+            table=self._task_keywords,
+            input_keywords=input_keywords)
+
+    def get_science_keywords(
+            self, input_keywords: List[str]) -> List[str]:
+        """Get the list of "science" type keywords from an input list
+        of keywords that might include other type of keywords and alternate
+        forms of keywords.
+        """
+        return self._get_keywords_in_table(
+            table=self._science_keywords,
+            input_keywords=input_keywords)
+
+    def _get_keywords_in_table(self, *, table, input_keywords) -> List[str]:
+        input_keywords = [k.lower().strip() for k in input_keywords]
+
+        output_keywords: List[str] = []
+
+        for input_keyword in input_keywords:
+            if input_keyword in table.keys():
+                # Keyword is in group and already the canonical form
+                output_keywords.append(input_keyword)
+            else:
+                # See if the keyword is an alternative form
+                for keyword, alternates in table.items():
+                    if input_keyword in alternates:
+                        output_keywords.append(keyword)
+
+        return output_keywords

--- a/astropylibrarian/reducers/tutorial.py
+++ b/astropylibrarian/reducers/tutorial.py
@@ -124,7 +124,7 @@ class ReducedTutorial:
                 root_section=root_section,
                 headers=[],
                 header_callback=lambda x: x.rstrip('¶'),
-                content_callback=lambda x: x.strip()):
+                content_callback=clean_content):
             if not self._is_ignored_section(s):
                 self._sections.append(s)
 
@@ -140,8 +140,7 @@ class ReducedTutorial:
                         base_url=self._url,
                         headers=[h1_heading],
                         header_callback=lambda x: x.rstrip('¶'),
-                        content_callback=lambda x: x.strip()
-                        ):
+                        content_callback=clean_content):
                     if not self._is_ignored_section(s):
                         self._sections.append(s)
 
@@ -179,3 +178,11 @@ class ReducedTutorial:
     def _parse_comma_list(element: lxml.html.HtmlElement) -> List[str]:
         content = element.text_content()
         return [s.strip() for s in content.split(',')]
+
+
+def clean_content(x: str) -> str:
+    x = x.strip()
+    x = x.replace(r'\n', ' ')
+    x = x.replace('\n', ' ')
+    x = x.replace('\\', ' ')
+    return x

--- a/astropylibrarian/reducers/utils.py
+++ b/astropylibrarian/reducers/utils.py
@@ -99,6 +99,7 @@ def iter_sphinx_sections(
             )
         else:
             if content_callback:
+                print('cleaning content')
                 text_elements.append(content_callback(element.text_content()))
             else:
                 text_elements.append(element.text_content())

--- a/astropylibrarian/reducers/utils.py
+++ b/astropylibrarian/reducers/utils.py
@@ -99,7 +99,6 @@ def iter_sphinx_sections(
             )
         else:
             if content_callback:
-                print('cleaning content')
                 text_elements.append(content_callback(element.text_content()))
             else:
                 text_elements.append(element.text_content())

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -4,6 +4,7 @@
 
 __all__ = ['index_tutorial']
 
+import json
 from typing import TYPE_CHECKING, List
 
 from astropylibrarian.reducers.tutorial import ReducedTutorial
@@ -63,6 +64,14 @@ async def index_tutorial(
                for s in tutorial.sections]
     record_objects = [r.data for r in records]
     print(f'Indexing {len(record_objects)} objects')
+
+    for data in record_objects:
+        try:
+            json.dumps(data)
+        except Exception:
+            print(data)
+
+    print('json ok')
 
     index = algolia_client.init_index(index_name)
     index.save_objects(record_objects).wait()

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -6,6 +6,7 @@ __all__ = ['index_tutorial']
 
 import json
 import asyncio
+import logging
 from typing import TYPE_CHECKING, List
 
 from algoliasearch.responses import MultipleResponse
@@ -17,6 +18,9 @@ from .download import download_html
 if TYPE_CHECKING:
     import aiohttp
     from algoliasearch.search_client import SearchClient
+
+
+logger = logging.getLogger(__name__)
 
 
 async def index_tutorial(
@@ -59,7 +63,7 @@ async def index_tutorial(
        <https://www.algolia.com/doc/api-reference/api-methods/save-objects/>`_)
     """
     tutorial_html = await download_html(url=url, http_client=http_client)
-    print(f'Downloaded {url}')
+    logger.debug('Downloaded %s')
 
     tutorial = ReducedTutorial(html_source=tutorial_html, url=url)
 
@@ -67,10 +71,10 @@ async def index_tutorial(
                for s in tutorial.sections]
 
     record_objects = [r.data for r in records]
-    print(f'Indexing {len(record_objects)} objects')
+    logger.debug(f'Indexing {len(record_objects)} objects')
 
     for r in record_objects:
-        print(json.dumps(r, indent=2))
+        logger.debug(json.dumps(r, indent=2))
 
     index = algolia_client.init_index(index_name)
     tasks = [index.save_object_async(d) for d in record_objects]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ dev =
     pytest==6.1.2
     pytest-flake8==1.0.6
     pytest-mypy==0.8.0
+    pre-commit
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
 
 [options]
 zip_safe = False
+include_package_data = True
 python_requires = >=3.7
 packages = find:
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     # https://www.algolia.com/doc/api-client/advanced/asynchronous-environments/python/language=python
     aiohttp>=2.0,<4.0
     async_timeout>=<4.0
+    PyYAML
 
 [options.extras_require]
 dev =

--- a/tests/data/tutorials/Coordinates-Transform.html
+++ b/tests/data/tutorials/Coordinates-Transform.html
@@ -34,9 +34,9 @@
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("../searchindex.js"); });
   </script>
-  
+
   <script type="text/javascript" id="searchindexloader"></script>
-   
+
 
   </head><body>
 
@@ -70,11 +70,11 @@
 <div class="container">
   <div class="row">
 
-    
-    
-    
 
-    
+
+
+
+
     <div class="col-md-3">
       <div id="sidebar" class="bs-sidenav card" role="complementary">
         <h3>Table of contents</h3>
@@ -112,7 +112,7 @@
 
       </div>
     </div>
-    
+
 
     <div class="col-md-9">
       <div class="content-padding card">
@@ -671,7 +671,7 @@ last section of this tutorial.</p>
 
 </div>
       </div>
-      
+
     </div>
   </div>
 </div>
@@ -679,7 +679,7 @@ last section of this tutorial.</p>
   <div class="container">
     <p class="pull-right">
       <a href="#">Back to top</a>
-      
+
     </p>
     <p>
     Created using <a href="http://sphinx-doc.org/">Sphinx</a> 2.2.1.

--- a/tests/data/tutorials/color-excess.html
+++ b/tests/data/tutorials/color-excess.html
@@ -34,9 +34,9 @@
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("../searchindex.js"); });
   </script>
-  
+
   <script type="text/javascript" id="searchindexloader"></script>
-   
+
 
   </head><body>
 
@@ -70,11 +70,11 @@
 <div class="container">
   <div class="row">
 
-    
-    
-    
 
-    
+
+
+
+
     <div class="col-md-3">
       <div id="sidebar" class="bs-sidenav card" role="complementary">
         <h3>Table of contents</h3>
@@ -97,7 +97,7 @@
 
       </div>
     </div>
-    
+
 
     <div class="col-md-9">
       <div class="content-padding card">
@@ -646,7 +646,7 @@ depends on the shape of the background source flux.</p>
 
 </div>
       </div>
-      
+
     </div>
   </div>
 </div>
@@ -654,7 +654,7 @@ depends on the shape of the background source flux.</p>
   <div class="container">
     <p class="pull-right">
       <a href="#">Back to top</a>
-      
+
     </p>
     <p>
     Created using <a href="http://sphinx-doc.org/">Sphinx</a> 2.2.1.

--- a/tests/test_algolia_records.py
+++ b/tests/test_algolia_records.py
@@ -37,13 +37,13 @@ def test_tutorialsectionrecord(color_excess_tutorial):
         'baseUrl': color_excess_tutorial.url,
         'url': f'{color_excess_tutorial.url}#learning-goals',
         'content': (
-            'Investigate extinction curve shapes\n'
-            'Deredden spectral energy distributions and spectra\n'
-            'Calculate photometric extinction and reddening\n'
+            'Investigate extinction curve shapes '
+            'Deredden spectral energy distributions and spectra '
+            'Calculate photometric extinction and reddening '
             'Calculate synthetic photometry for a dust-reddened star by '
-            'combining\ndust_extinction and synphot\n'
-            'Convert from frequency to wavelength with astropy.unit\n'
-            'equivalencies\n'
+            'combining dust_extinction and synphot '
+            'Convert from frequency to wavelength with astropy.unit '
+            'equivalencies '
             'Unit support for plotting with astropy.visualization'
         ),
         'importance': 2,
@@ -53,15 +53,21 @@ def test_tutorialsectionrecord(color_excess_tutorial):
             'Stephanie T. Douglas',
             'Kelle Cruz'],
         'contentType': 'tutorial',
-        'keywords': [
-            'dust extinction',
+        'astropy_package_keywords': [
+            'dust_extinction',
             'synphot',
             'astroquery',
             'units',
+        ],
+        'python_package_keywords': [],
+        'task_keywords': [
             'photometry',
+        ],
+        'science_keywords': [
             'extinction',
             'physics',
-            'observational astronomy'],
+            'observational astronomy'
+        ],
         'h1': ("Analyzing interstellar reddening and calculating synthetic "
                "photometry"),
         'h2': 'Learning Goals',

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -20,7 +20,7 @@ def test_get_astropy_package_keywords() -> None:
     ]
 
     keyworddb = KeywordDb.load()
-    assert keyworddb.get_astropy_package_keywords(inputs) == outputs
+    assert keyworddb.filter_keywords(inputs, 'astropy_package') == outputs
 
 
 def test_get_python_package_keywords() -> None:
@@ -32,7 +32,7 @@ def test_get_python_package_keywords() -> None:
     outputs = ["numpy"]
 
     keyworddb = KeywordDb.load()
-    assert keyworddb.get_python_package_keywords(inputs) == outputs
+    assert keyworddb.filter_keywords(inputs, 'python_package') == outputs
 
 
 def test_task_keywords() -> None:
@@ -44,7 +44,7 @@ def test_task_keywords() -> None:
     outputs = ["contour plots", "object-oriented programming"]
 
     keyworddb = KeywordDb.load()
-    assert keyworddb.get_task_keywords(inputs) == outputs
+    assert keyworddb.filter_keywords(inputs, 'task') == outputs
 
 
 def test_science_keywords() -> None:
@@ -61,4 +61,4 @@ def test_science_keywords() -> None:
     ]
 
     keyworddb = KeywordDb.load()
-    assert keyworddb.get_science_keywords(inputs) == outputs
+    assert keyworddb.filter_keywords(inputs, 'science') == outputs

--- a/tests/test_keywords.py
+++ b/tests/test_keywords.py
@@ -1,0 +1,64 @@
+"""Tests for the astropylibrarian.keywords module."""
+
+from astropylibrarian.keywords import KeywordDb
+
+
+def test_load() -> None:
+    keyworddb = KeywordDb.load()
+    assert isinstance(keyworddb, KeywordDb)
+
+
+def test_get_astropy_package_keywords() -> None:
+    inputs = [
+        'astroquery',  # canonical keyword
+        'astropy.coordinates',  # alternate form
+        'numpy'  # not astropy package keyword
+    ]
+    outputs = [
+        'astroquery',
+        'coordinates'
+    ]
+
+    keyworddb = KeywordDb.load()
+    assert keyworddb.get_astropy_package_keywords(inputs) == outputs
+
+
+def test_get_python_package_keywords() -> None:
+    inputs = [
+        'astroquery',  # wrong type
+        'astropy.coordinates',  # wrong type
+        'numpy'  # canonical keyword
+    ]
+    outputs = ["numpy"]
+
+    keyworddb = KeywordDb.load()
+    assert keyworddb.get_python_package_keywords(inputs) == outputs
+
+
+def test_task_keywords() -> None:
+    inputs = [
+        'astroquery',  # wrong type
+        'contour plots',  # canonical form
+        'OOP'  # alternate form, also uppercase
+    ]
+    outputs = ["contour plots", "object-oriented programming"]
+
+    keyworddb = KeywordDb.load()
+    assert keyworddb.get_task_keywords(inputs) == outputs
+
+
+def test_science_keywords() -> None:
+    inputs = [
+        'astroquery',  # wrong type
+        'astrodynamics',
+        'x-ray astronomy',
+        'extinction'
+    ]
+    outputs = [
+        'astrodynamics',
+        'x-ray astronomy',
+        'extinction'
+    ]
+
+    keyworddb = KeywordDb.load()
+    assert keyworddb.get_science_keywords(inputs) == outputs


### PR DESCRIPTION
In our search interface, we want to have separate filters for different types of keywords: Astropy package, Python package, science, and task. However, in our source documents we don't separate these keywords; they're all listed together. The purpose of this PR is to add a way to classify keywords into one of the four types.

To do this, we have a YAML document that's part of learn-astropy-librarian, at `astropylibrarian/data/keywords.yaml`. For us to recognize a keyword, it needs to be listed in this file. The alternative would be to change our metadata format inside to tutorials to provide this classification; which would be a more decentralized approach. This, on the other hand, centralizes keyword curation which might actually be a good thing.