### PR TITLE
Adjust "importance" field for Guides

### DIFF
--- a/astropylibrarian/algolia/records.py
+++ b/astropylibrarian/algolia/records.py
@@ -297,8 +297,15 @@ class GuideRecord(AlgoliaRecord):
         else:
             thumbnail_url = None
 
-        # TODO change importance so all pages below the homepage are reduced
-        # in importance?
+        # The importance of 1 is reserved for the homepage URL so that the
+        # homepage is featured in default listings. All other records have
+        # importance bumped down lower.
+        if (page.url == site_metadata.homepage_url) and (
+            section.header_level == 1
+        ):
+            importance = 1
+        else:
+            importance = section.header_level + 1
 
         kwargs: Dict[str, Any] = {
             "objectID": cls.compute_object_id_for_section(section),
@@ -308,7 +315,7 @@ class GuideRecord(AlgoliaRecord):
             "root_title": site_metadata.title,
             "root_summary": site_metadata.description,
             "base_url": page.url,
-            "importance": section.header_level,  # FIXME?
+            "importance": importance,
             "content": section.content,
             "thumbnail_url": thumbnail_url,
         }

--- a/astropylibrarian/reducers/jupyterbook.py
+++ b/astropylibrarian/reducers/jupyterbook.py
@@ -217,6 +217,15 @@ class JupyterBookMetadata(BaseModel):
     page_urls: List[HttpUrl]
     """URLs of pages in the JupyterBook."""
 
+    @property
+    def all_page_urls(self) -> List[str]:
+        """The ``page_urls`` along with the ``homepage_url``."""
+        return list(
+            set(
+                [str(url) for url in self.page_urls] + [str(self.homepage_url)]
+            )
+        )
+
     @validator("root_url")
     def validate_root_url(cls, v: str) -> str:
         """Validate the root url so it points to a directory, not a "file"."""

--- a/astropylibrarian/reducers/jupyterbook.py
+++ b/astropylibrarian/reducers/jupyterbook.py
@@ -207,6 +207,13 @@ class JupyterBookMetadata(BaseModel):
     source_repository: Optional[HttpUrl]
     """The URL of the book's source repository (i.e. GitHub repository)."""
 
+    homepage_url: HttpUrl
+    """The URL of the homepage.
+
+    This is not necessarily the same as the root_url, which redirects to this
+    homepage_url.
+    """
+
     page_urls: List[HttpUrl]
     """URLs of pages in the JupyterBook."""
 

--- a/astropylibrarian/workflows/indexjupyterbook.py
+++ b/astropylibrarian/workflows/indexjupyterbook.py
@@ -229,6 +229,7 @@ def extract_homepage_metadata(
         logo_url=homepage.logo_url,
         description=homepage.first_paragraph or "",
         source_repository=homepage.github_repository,
+        homepage_url=homepage.url,
         page_urls=homepage.page_urls,
     )
     return md

--- a/astropylibrarian/workflows/indexjupyterbook.py
+++ b/astropylibrarian/workflows/indexjupyterbook.py
@@ -65,10 +65,7 @@ async def index_jupyterbook(
         html_page=homepage, root_url=url
     )
     logger.debug("Extracted JupyterBook metadata\n%s", homepage_metadata)
-    # Include the homepage with the list of URLs
-    page_urls = set(
-        [str(url) for url in homepage_metadata.page_urls] + [homepage.url]
-    )
+    page_urls = homepage_metadata.all_page_urls
     index_epoch = generate_index_epoch()
     tasks = [
         asyncio.create_task(

--- a/tests/test_algolia_records.py
+++ b/tests/test_algolia_records.py
@@ -145,7 +145,7 @@ def test_guiderecord(
     assert data["h1"] == "1.4. Calibration overview"
     assert data["h2"] == "1.4.1. This noise cannot be removed from CCD images"
     assert data["h3"] == "1.4.1.1. First, some stars with noise"
-    assert data["importance"] == 3
+    assert data["importance"] == 4
     assert data["content"] == (
         "The image below shows stars (the larger “blobs” in the image) but "
         "shows quite a bit of noise as well (the much smaller “dots”)."


### PR DESCRIPTION
This PR adjusts how the `importance` field is computed for Algolia records for guides (and any other multi-page resource).

The background is that `importance` normally corresponds to the heading level of the record (1 for h1, 2 for h2, and so on). This lets us preferentially show records for "root" sections preferentially, rather than dropping a user randomly into a random subsection if there's no query-based relevance to tell the sorting algorithm otherwise.

For multi-page guides, we now want to preferentially show users the top of the JupyterBook's homepage. We do this by reserving an `importance` of `1` for the `h1` record of the JupyterBook homepage; all other records have `importance` that is one larger than would be indicated by the heading level.