### PR TITLE
Add Priority field

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,9 @@ astropylibrarian index tutorial
       --index TEXT        Name of the Algolia index.  [env var: ALGOLIA_INDEX;
                           required]
 
+      --priority INTEGER  Priority for default sorting (higher numbers appear
+                          first)  [default: 0]
+
       --help              Show this message and exit.
 
 astropylibrarian index guide
@@ -73,6 +76,9 @@ astropylibrarian index guide
       --algolia-key TEXT  Algolia API key.  [env var: ALGOLIA_KEY; required]
       --index TEXT        Name of the Algolia index.  [env var: ALGOLIA_INDEX;
                           required]
+
+      --priority INTEGER  Priority for default sorting (higher numbers appear
+                          first)  [default: 0]
 
       --help              Show this message and exit.
 

--- a/astropylibrarian/cli/index.py
+++ b/astropylibrarian/cli/index.py
@@ -32,6 +32,10 @@ def tutorial(
     index: str = typer.Option(
         ..., help="Name of the Algolia index.", envvar="ALGOLIA_INDEX"
     ),
+    priority: int = typer.Option(
+        0,
+        help="Priority for default sorting (higher numbers appear first)",
+    ),
 ) -> None:
     """Index a single tutorial."""
     event_loop = asyncio.get_event_loop()
@@ -41,19 +45,23 @@ def tutorial(
             algolia_id=algolia_id,
             algolia_key=algolia_key,
             index=index,
+            priority=priority,
         )
     )
 
 
 async def run_index_tutorial(
-    *, url: str, algolia_id: str, algolia_key: str, index: str
+    *, url: str, algolia_id: str, algolia_key: str, index: str, priority: int
 ) -> None:
     async with aiohttp.ClientSession() as http_client:
         async with AlgoliaIndex(
             key=algolia_key, app_id=algolia_id, name=index
         ) as algolia_index:
             await index_tutorial(
-                url=url, http_client=http_client, algolia_index=algolia_index
+                url=url,
+                http_client=http_client,
+                algolia_index=algolia_index,
+                priority=priority,
             )
 
 
@@ -74,6 +82,10 @@ def guide(
     index: str = typer.Option(
         ..., help="Name of the Algolia index.", envvar="ALGOLIA_INDEX"
     ),
+    priority: int = typer.Option(
+        0,
+        help="Priority for default sorting (higher numbers appear first)",
+    ),
 ) -> None:
     """Index a guide."""
     event_loop = asyncio.get_event_loop()
@@ -83,12 +95,13 @@ def guide(
             algolia_id=algolia_id,
             algolia_key=algolia_key,
             index=index,
+            priority=priority,
         )
     )
 
 
 async def run_index_guide(
-    *, url: str, algolia_id: str, algolia_key: str, index: str
+    *, url: str, algolia_id: str, algolia_key: str, index: str, priority: int
 ) -> None:
     async with aiohttp.ClientSession() as http_client:
         async with AlgoliaIndex(
@@ -98,4 +111,5 @@ async def run_index_guide(
                 url=url,
                 http_client=http_client,
                 algolia_index=algolia_index,
+                priority=priority,
             )

--- a/astropylibrarian/reducers/jupyterbook.py
+++ b/astropylibrarian/reducers/jupyterbook.py
@@ -217,6 +217,9 @@ class JupyterBookMetadata(BaseModel):
     page_urls: List[HttpUrl]
     """URLs of pages in the JupyterBook."""
 
+    priority: int
+    """A priority level that elevates a guide in the UI's default sorting."""
+
     @property
     def all_page_urls(self) -> List[str]:
         """The ``page_urls`` along with the ``homepage_url``."""

--- a/astropylibrarian/reducers/tutorial.py
+++ b/astropylibrarian/reducers/tutorial.py
@@ -165,7 +165,9 @@ class ReducedTutorial:
         else:
             return False
 
-    def iter_records(self, *, index_epoch: str) -> Iterator[TutorialRecord]:
+    def iter_records(
+        self, *, index_epoch: str, priority: int
+    ) -> Iterator[TutorialRecord]:
         """Iterate over Algolia records in the tutorial."""
         keyworddb = KeywordDb.load()
         for section in self.sections:
@@ -174,10 +176,11 @@ class ReducedTutorial:
                 section=section,
                 keyworddb=keyworddb,
                 index_epoch=index_epoch,
+                priority=priority,
             )
 
     def iter_algolia_objects(
-        self, *, index_epoch: str
+        self, *, index_epoch: str, priority: int
     ) -> Iterator[Dict[str, Any]]:
         """Iterate over all objects that are extractable from the tutorial in
         a format ready to use with the algoliasearch client.
@@ -188,7 +191,9 @@ class ReducedTutorial:
             An object compatible with algolia search ``save_objects``-type
             methods.
         """
-        for record in self.iter_records(index_epoch=index_epoch):
+        for record in self.iter_records(
+            index_epoch=index_epoch, priority=priority
+        ):
             yield record.export_to_algolia()
 
     def _set_summary_on_h1_section(self) -> None:

--- a/astropylibrarian/workflows/indexjupyterbook.py
+++ b/astropylibrarian/workflows/indexjupyterbook.py
@@ -40,6 +40,7 @@ async def index_jupyterbook(
     url: str,
     http_client: aiohttp.ClientSession,
     algolia_index: AlgoliaIndexType,
+    priority: int,
 ) -> List[str]:
     """Ingest a Jupyter Book site as a Learn Astropy Guide.
 
@@ -52,6 +53,8 @@ async def index_jupyterbook(
     algolia_index
         Algolia index created by the
         `astropylibrarian.workflows.client.AlgoliaIndex` context manager.
+    priority : int
+        A priority level that elevates a guide in the UI's default sorting.
 
     Returns
     -------
@@ -62,7 +65,7 @@ async def index_jupyterbook(
     homepage = await download_homepage(url=url, http_client=http_client)
     logger.debug("Downloaded %s", url)
     homepage_metadata = extract_homepage_metadata(
-        html_page=homepage, root_url=url
+        html_page=homepage, root_url=url, priority=priority
     )
     logger.debug("Extracted JupyterBook metadata\n%s", homepage_metadata)
     page_urls = homepage_metadata.all_page_urls
@@ -200,7 +203,7 @@ def parse_redirect_url(*, content: str, source_url: str) -> str:
 
 
 def extract_homepage_metadata(
-    *, html_page: HtmlPage, root_url: str
+    *, html_page: HtmlPage, root_url: str, priority: int
 ) -> JupyterBookMetadata:
     """Extract JupyterBook project metadata from it's homepage.
 
@@ -213,6 +216,8 @@ def extract_homepage_metadata(
         input to `index_jupyterbook` and becomes a unique identifier for all
         Algolia records related to a JupyterBook, across all of a JupyterBook's
         pages.
+    priority : int
+        A priority level that elevates a guide in the UI's default sorting.
 
     Returns
     -------
@@ -228,5 +233,6 @@ def extract_homepage_metadata(
         source_repository=homepage.github_repository,
         homepage_url=homepage.url,
         page_urls=homepage.page_urls,
+        priority=priority,
     )
     return md

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -26,6 +26,7 @@ async def index_tutorial(
     url: str,
     http_client: aiohttp.ClientSession,
     algolia_index: AlgoliaIndexType,
+    priority: int,
 ) -> List[str]:
     """Asynchronously save records for a tutorial to Algolia (awaitable
     function).
@@ -39,6 +40,8 @@ async def index_tutorial(
     algolia_index
         Algolia index created by the
         `astropylibrarian.workflows.client.AlgoliaIndex` context manager.
+    priority : int
+        A priority level that elevates a tutorial in the UI's default sorting.
 
     Returns
     -------
@@ -66,7 +69,10 @@ async def index_tutorial(
 
     index_epoch = generate_index_epoch()
     records = [
-        r for r in tutorial.iter_algolia_objects(index_epoch=index_epoch)
+        r
+        for r in tutorial.iter_algolia_objects(
+            index_epoch=index_epoch, priority=priority
+        )
     ]
     logger.debug("Indexing %d records for tutorial at %s", len(records), url)
 

--- a/tests/test_algolia_records.py
+++ b/tests/test_algolia_records.py
@@ -23,7 +23,9 @@ def test_tutorialsectionrecord(color_excess_tutorial: HtmlTestData) -> None:
     index_epoch = generate_index_epoch()
     records = [
         r
-        for r in reduced_tutorial.iter_algolia_objects(index_epoch=index_epoch)
+        for r in reduced_tutorial.iter_algolia_objects(
+            index_epoch=index_epoch, priority=0
+        )
     ]
     data = records[0]
 
@@ -92,6 +94,7 @@ def test_tutorialsectionrecord(color_excess_tutorial: HtmlTestData) -> None:
         "thumbnail_url": (
             "http://learn.astropy.org/_images/color-excess_9_0.png"
         ),
+        "priority": 0,
     }
 
 
@@ -101,6 +104,7 @@ def test_guiderecord(
     metadata = extract_homepage_metadata(
         html_page=ccd_guide_00_00,
         root_url="http://www.astropy.org/ccd-reduction-and-photometry-guide/",
+        priority=1,
     )
     page = JupyterBookPage(ccd_guide_01_05)
     index_epoch = generate_index_epoch()
@@ -162,3 +166,4 @@ def test_guiderecord(
         "http://www.astropy.org/ccd-reduction-and-photometry-guide/_images/"
         "01-05-Calibration-overview_6_1.png"
     )
+    assert data["priority"] == 1

--- a/tests/test_workflows_indexjupyterbook.py
+++ b/tests/test_workflows_indexjupyterbook.py
@@ -51,6 +51,7 @@ def test_extract_homepage_metadata(ccd_guide_00_00: HtmlTestData) -> None:
     md = extract_homepage_metadata(
         html_page=ccd_guide_00_00,
         root_url="http://www.astropy.org/ccd-reduction-and-photometry-guide/",
+        priority=1,
     )
     assert md.title == "CCD Data Reduction Guide"
     assert md.logo_url == (
@@ -73,3 +74,4 @@ def test_extract_homepage_metadata(ccd_guide_00_00: HtmlTestData) -> None:
         "http://www.astropy.org/ccd-reduction-and-photometry-guide/notebooks/"
         "01-00-Understanding-an-astronomical-CCD-image.html"
     ) in md.page_urls
+    assert md.priority == 1


### PR DESCRIPTION
The priority field in the Algolia record schema allows us to place specific resources higher in the default view on the homepage. For example, we're ingesting the CCD processing guide with `--priority 10` so that it appears first. Within the integer priority levels, we can curate the order that different resources appear in the default search. (Note that in the front-end implementation of this, once a user begins to type a query, the index automatically switches to relevance mode and ignores the priority field).