### PR TITLE
Add ability to index tutorials from local files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,38 @@ astropylibrarian index tutorial
       --path PATH         Local path of tutorial HTML, if available.
       --help              Show this message and exit.
 
+astropylibrarian index tutorial-site
+------------------------------------
+
+
+::
+
+  Usage: astropylibrarian index tutorial-site [OPTIONS] SITE_DIR URL
+
+    Index a directory of tutorial HTML files.
+
+    This command is useful for automated CI workflows. The site_dir argument
+    is the directory of tutorials built by nbcollection and url is the root
+    URL where these tutorials are published on the web. This command indexes
+    each HTML file as a tutorial, except for those with paths specified in the
+    --ignore argument. The root index.html file is always ignored.
+
+  Arguments:
+    SITE_DIR  Local path tutorial build directory  [required]
+    URL       Base URL for tutorials.  [required]
+
+  Options:
+    --algolia-id TEXT   Algolia app ID.  [env var: ALGOLIA_ID; required]
+    --algolia-key TEXT  Algolia API key.  [env var: ALGOLIA_KEY; required]
+    --index TEXT        Name of the Algolia index.  [env var: ALGOLIA_INDEX;
+                        required]
+
+    --ignore TEXT       List of HTML files to ignore from indexing. The root
+                        index.html file is always excluded.  [default:
+                        (dynamic)]
+
+    --help              Show this message and exit.
+
 astropylibrarian index guide
 ----------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ astropylibrarian index tutorial
       --priority INTEGER  Priority for default sorting (higher numbers appear
                           first)  [default: 0]
 
+      --path PATH         Local path of tutorial HTML, if available.
       --help              Show this message and exit.
 
 astropylibrarian index guide

--- a/astropylibrarian/cli/index.py
+++ b/astropylibrarian/cli/index.py
@@ -10,7 +10,7 @@ import typer
 
 from astropylibrarian.algolia.client import AlgoliaIndex
 from astropylibrarian.workflows.indexjupyterbook import index_jupyterbook
-from astropylibrarian.workflows.indextutorial import index_tutorial
+from astropylibrarian.workflows.indextutorial import index_tutorial_from_url
 
 app = typer.Typer(short_help="Content indexing commands.")
 
@@ -57,7 +57,7 @@ async def run_index_tutorial(
         async with AlgoliaIndex(
             key=algolia_key, app_id=algolia_id, name=index
         ) as algolia_index:
-            await index_tutorial(
+            await index_tutorial_from_url(
                 url=url,
                 http_client=http_client,
                 algolia_index=algolia_index,

--- a/astropylibrarian/cli/index.py
+++ b/astropylibrarian/cli/index.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
-from typing import Optional
+from pathlib import Path, PosixPath
+from typing import Awaitable, List, Optional
 
 import aiohttp
 import typer
@@ -57,6 +57,93 @@ def tutorial(
             path=path,
         )
     )
+
+
+@app.command("tutorial-site")
+def tutorial_site(
+    site_dir: Path = typer.Argument(
+        ..., help="Local path tutorial build directory"
+    ),
+    url: str = typer.Argument(..., help="Base URL for tutorials."),
+    algolia_id: str = typer.Option(
+        ..., help="Algolia app ID.", envvar="ALGOLIA_ID"
+    ),
+    algolia_key: str = typer.Option(
+        ...,
+        help="Algolia API key.",
+        envvar="ALGOLIA_KEY",
+        prompt=True,
+        confirmation_prompt=False,
+        hide_input=True,
+    ),
+    index: str = typer.Option(
+        ..., help="Name of the Algolia index.", envvar="ALGOLIA_INDEX"
+    ),
+    ignore: List[str] = typer.Option(
+        lambda: ["index.html"],
+        help=(
+            "List of HTML files to ignore from indexing. The root index.html "
+            "file is always excluded."
+        ),
+    ),
+) -> None:
+    """Index a directory of tutorial HTML files.
+
+    This command is useful for automated CI workflows. The site_dir argument
+    is the directory of tutorials built by nbcollection and url is the root
+    URL where these tutorials are published on the web. This command indexes
+    each HTML file as a tutorial, except for those with paths specified in
+    the --ignore argument. The root index.html file is always ignored.
+    """
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(
+        run_index_tutorial_site(
+            site_dir=site_dir,
+            root_url=url,
+            algolia_id=algolia_id,
+            algolia_key=algolia_key,
+            index=index,
+            ignore_paths=ignore,
+        )
+    )
+
+
+async def run_index_tutorial_site(
+    *,
+    site_dir: Path,
+    root_url: str,
+    algolia_id: str,
+    algolia_key: str,
+    index: str,
+    ignore_paths: List[str],
+) -> None:
+    # For consistency when building page urls
+    if root_url.endswith("/"):
+        root_url.rstrip("/")
+
+    async with aiohttp.ClientSession() as http_client:
+        async with AlgoliaIndex(
+            key=algolia_key, app_id=algolia_id, name=index
+        ) as algolia_index:
+            site_dir.resolve()
+            html_paths = site_dir.glob("**/*.html")
+            tasks: List[Awaitable] = []
+            for html_path in html_paths:
+                relative_path = str(PosixPath(html_path.relative_to(site_dir)))
+                if relative_path in ignore_paths:
+                    continue
+                page_url = f"{root_url}/{relative_path}"
+                tasks.append(
+                    index_tutorial_from_path(
+                        path=html_path,
+                        url=page_url,
+                        http_client=http_client,
+                        algolia_index=algolia_index,
+                        # hard-coded for now, will add a config system later
+                        priority=0,
+                    )
+                )
+            asyncio.gather(*tasks)
 
 
 async def run_index_tutorial(

--- a/astropylibrarian/resources.py
+++ b/astropylibrarian/resources.py
@@ -1,10 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Basic APIs for dealing with resources on the web, such as web pages."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Optional
+from pathlib import Path
+from typing import Any, Mapping, Optional, Type, TypeVar
 
 import lxml.html
+
+HtmlPageType = TypeVar("HtmlPageType", bound="HtmlPage")
 
 
 @dataclass
@@ -32,3 +37,19 @@ class HtmlPage:
     def parse(self) -> lxml.html.HtmlElement:
         """Parse the HTML content with ``lxml.html``."""
         return lxml.html.document_fromstring(self.html)
+
+    @classmethod
+    def from_path(
+        cls: Type[HtmlPageType], *, path: Path, url: str
+    ) -> HtmlPageType:
+        """Open an HtmlPage from a local file.
+
+        Parameters
+        ----------
+        path : `pathlib.Path`
+            Path to the local HTML file.
+        url : `str`
+            The URL where the tutorial is publised.
+        """
+        html = path.read_text()
+        return cls(html=html, url=url)

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -62,7 +62,7 @@ async def index_tutorial_from_url(
     1. Download the HTML page
        (`~astropylibrarian.workflows.download.download_html`)
     2. Reduce the tutorial
-       (~`astropylibrarian.reducers.tutorial.ReducedTutorial`)
+       (`~astropylibrarian.reducers.tutorial.ReducedTutorial`)
     3. Create records for each section
        (`~astropylibrarian.algolia.records.TutorialSectionRecord`)
     4. Save each record to Algolia (`index.save_objects
@@ -115,7 +115,7 @@ async def index_tutorial_from_path(
 
     1. Open the HTML page
     2. Reduce the tutorial
-       (~`astropylibrarian.reducers.tutorial.ReducedTutorial`)
+       (`~astropylibrarian.reducers.tutorial.ReducedTutorial`)
     3. Create records for each section
        (`~astropylibrarian.algolia.records.TutorialSectionRecord`)
     4. Save each record to Algolia (`index.save_objects

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,17 +13,16 @@ class HtmlTestData(HtmlPage):
     """A container for HTML pages cached in the repo's tests/data directory."""
 
     @classmethod
-    def from_path(cls, *, path: str, url: str) -> HtmlTestData:
+    def from_test_path(cls, *, path: str, url: str) -> HtmlTestData:
         data_path = Path(__file__).parent / "data"
-        source_path = data_path.joinpath(path)
-        html = source_path.read_text()
-        return cls(html=html, url=url)
+        source_path = data_path.joinpath(Path(path))
+        return cls.from_path(path=source_path, url=url)
 
 
 @pytest.fixture(scope="session")
 def color_excess_tutorial() -> HtmlTestData:
     """The color-excess.html tutorial page."""
-    return HtmlTestData.from_path(
+    return HtmlTestData.from_test_path(
         path="tutorials/color-excess.html",
         url="http://learn.astropy.org/rst-tutorials/color-excess.html",
     )
@@ -38,7 +37,7 @@ def color_excess_tutorial_v2() -> HtmlTestData:
     Instead of div elements with "section" classes, sections now use the
     section tag itself without classes.
     """
-    return HtmlTestData.from_path(
+    return HtmlTestData.from_test_path(
         path="tutorials/color-excess-v2.html",
         url="http://learn.astropy.org/rst-tutorials/color-excess.html",
     )
@@ -47,7 +46,7 @@ def color_excess_tutorial_v2() -> HtmlTestData:
 @pytest.fixture(scope="session")
 def coordinates_transform_tutorial() -> HtmlTestData:
     """The Coordinates-Transform.html tutorial page."""
-    return HtmlTestData.from_path(
+    return HtmlTestData.from_test_path(
         path="tutorials/Coordinates-Transform.html",
         url="http://learn.astropy.org/rst-tutorials/"
         "Coordinates-Transform.html",
@@ -57,7 +56,7 @@ def coordinates_transform_tutorial() -> HtmlTestData:
 @pytest.fixture(scope="session")
 def nbcollection_coordinates_transform_tutorial() -> HtmlTestData:
     """The nbcollection-generated Coordinates-Transform.html tutorial page."""
-    return HtmlTestData.from_path(
+    return HtmlTestData.from_test_path(
         path="nbcollection-tutorials/2-Coordinates-Transforms.html",
         url="http://learn.astropy.org/tutorials/2-Coordinates-Transforms.html",
     )
@@ -70,7 +69,7 @@ def ccd_guide_index() -> HtmlTestData:
     This page is the root file created by Jupyter Book, but which redirects
     to the first content page (notebooks/00-00-Preface.html).
     """
-    return HtmlTestData.from_path(
+    return HtmlTestData.from_test_path(
         path="ccd-guide/index.html",
         url="http://www.astropy.org/ccd-reduction-and-photometry-guide/"
         "index.html",
@@ -83,7 +82,7 @@ def ccd_guide_00_00() -> HtmlTestData:
 
     This is the CCD Guide homepage created by Jupyter Book.
     """
-    return HtmlTestData.from_path(
+    return HtmlTestData.from_test_path(
         path="ccd-guide/notebooks/00-00-Preface.html",
         url="http://www.astropy.org/ccd-reduction-and-photometry-guide/"
         "notebooks/00-00-Preface.html",
@@ -97,7 +96,7 @@ def ccd_guide_01_05() -> HtmlTestData:
     This is a regular content page from the CCD Guide homepage created by
     Jupyter Book.
     """
-    return HtmlTestData.from_path(
+    return HtmlTestData.from_test_path(
         path="ccd-guide/notebooks/01-05-Calibration-overview.html",
         url="http://www.astropy.org/ccd-reduction-and-photometry-guide/"
         "notebooks/01-05-Calibration-overview.html",

--- a/tests/test_workflows_indexjupyterbook.py
+++ b/tests/test_workflows_indexjupyterbook.py
@@ -42,7 +42,7 @@ from .conftest import HtmlTestData
 def test_detect_redirect(
     html_path: str, base_url: str, expected: Union[None, str]
 ) -> None:
-    html_page = HtmlTestData.from_path(path=html_path, url=base_url)
+    html_page = HtmlTestData.from_test_path(path=html_path, url=base_url)
     assert expected == detect_redirect(html_page)
 
 


### PR DESCRIPTION
Passing `--path` to `astropylibrarian index tutorial` allows the indexing command to get HTML from a local build, rather than sourcing it from the published website.

As well, adds a `astropylibrarian index tutorial-site` command that takes the directory of tutorial files rendered by nbcollection and does a bulk indexing of all discovered tutorial index files. The README includes the help for this command.

This `index tutorial-site` command is what we can run in GitHub Actions to re-index the tutorials while publishing updates ot Learn Astropy.

Fixes #21 