### PR TITLE
Fixes and improvements for tutorial indexing

### DIFF
--- a/astropylibrarian/cli/index.py
+++ b/astropylibrarian/cli/index.py
@@ -143,7 +143,7 @@ async def run_index_tutorial_site(
                         priority=0,
                     )
                 )
-            asyncio.gather(*tasks)
+            await asyncio.gather(*tasks)
 
 
 async def run_index_tutorial(

--- a/astropylibrarian/reducers/tutorial.py
+++ b/astropylibrarian/reducers/tutorial.py
@@ -152,7 +152,7 @@ class ReducedTutorial:
         for record in self.iter_records(
             index_epoch=index_epoch, priority=priority
         ):
-            yield record.export_to_algolia()
+            yield from record.export_capped_records_to_algolia()
 
     def _set_summary_on_h1_section(self) -> None:
         """Replaces the content of the "h1" section, which should be empty,

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -13,6 +13,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, List
 
+import algoliasearch.exceptions
+
 from astropylibrarian.algolia.client import generate_index_epoch
 from astropylibrarian.reducers.tutorial import get_tutorial_reducer
 from astropylibrarian.resources import HtmlPage
@@ -160,18 +162,31 @@ async def index_tutorial(
             index_epoch=index_epoch, priority=priority
         )
     ]
-    logger.debug(
+    logger.info(
         "Indexing %d records for tutorial at %s",
         len(records),
         tutorial_html.url,
     )
 
     saved_object_ids: List[str] = []
-    response = await algolia_index.save_objects_async(records)
+    try:
+        response = await algolia_index.save_objects_async(records)
+    except algoliasearch.exceptions.RequestException as e:
+        logger.error(
+            "Error saving objects for tutorial %s:\n%s",
+            tutorial_html.url,
+            str(e),
+        )
+        return []
     for r in response.raw_responses:
         _oids = r.get("objectIds", [])
         assert isinstance(_oids, list)
         saved_object_ids.extend(_oids)
+    logger.info(
+        "Finished saving %s records for tutorial at %s",
+        len(saved_object_ids),
+        tutorial_html.url,
+    )
 
     if saved_object_ids:
         await expire_old_records(

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, List
 
 from astropylibrarian.algolia.client import generate_index_epoch
 from astropylibrarian.reducers.tutorial import get_tutorial_reducer
+from astropylibrarian.resources import HtmlPage
 from astropylibrarian.workflows.download import download_html
 from astropylibrarian.workflows.expirerecords import expire_old_records
 
@@ -22,7 +23,6 @@ if TYPE_CHECKING:
     import aiohttp
 
     from astropylibrarian.client import AlgoliaIndexType
-    from astropylibrarian.resources import HtmlPage
 
 logger = logging.getLogger(__name__)
 

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -179,7 +179,7 @@ async def index_tutorial(
         )
         return []
     for r in response.raw_responses:
-        _oids = r.get("objectIds", [])
+        _oids = r.get("objectIDs", [])
         assert isinstance(_oids, list)
         saved_object_ids.extend(_oids)
     logger.info(

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     PyYAML
     pydantic
     typer
+    more-itertools
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
This PR implements several bug fixes and improvements for indexing, and indexing tutorials from a local site directory in particular.

- Fixes an import of HtmlPage seen when running an index against a local tutorial site. This was accidentally left as a typing-only import, whereas the `index_tutorial_from_path` workflow function needs to actually use the `HtmlPage` import itself.
- Improve the parsing algorithm for nbcollection-based tutorials. The old algorithm accidentally had unnecessary recursion!
- Algolia records are now split if they are larger than Algolia's size limit (10K for our current plan). This is relevant for long sections, as records are initially split at header elements on the page.