### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.1.0
     hooks:
       - id: trailing-whitespace
       - id: check-toml
@@ -11,18 +11,18 @@ repos:
         files: keywords\.yaml$
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: "5.10.1"
     hooks:
       - id: isort
         additional_dependencies:
           - toml
 
   - repo: https://github.com/psf/black
-    rev: 21.4b2
+    rev: "22.3.0"
     hooks:
       - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: "4.0.1"
     hooks:
       - id: flake8


### PR DESCRIPTION
In particular, the black update is needed to resolve an incompatibility with click.