### PR TITLE
Replace deprecated package `pkg_resources`

### DIFF
--- a/astropylibrarian/__init__.py
+++ b/astropylibrarian/__init__.py
@@ -5,10 +5,10 @@ search database.
 
 __all__ = ("__version__",)
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0"

--- a/astropylibrarian/__init__.py
+++ b/astropylibrarian/__init__.py
@@ -5,10 +5,8 @@ search database.
 
 __all__ = ("__version__",)
 
-from importlib.metadata import version, PackageNotFoundError
-
 try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
+    from ._version import __version__ 
+except ImportError:
     # package is not installed
-    __version__ = "0.0.0"
+    __version__ = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[project]
-name = "astropylibrarian"
-
 [tool.setuptools_scm]
 version_file = "astropylibrarian/_version.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,20 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=64",
     "wheel",
-    "setuptools_scm"
+    "setuptools_scm>=8"
 ]
-build-backend = 'setuptools.build_meta'
+build-backend = "setuptools.build_meta"
 
-[tools.setuptools_scm]
+[project]
+name = "astropylibrarian"
+
+[tool.setuptools_scm]
+version_file = "astropylibrarian/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ["py37"]
+target-version = ["py311"]
 exclude = '''
 /(
     \.eggs


### PR DESCRIPTION
[pkg_resources](https://setuptools.pypa.io/en/stable/pkg_resources.html) is deprecated; this PR replaces its single use in the code with [importlib_metadata](https://pypi.org/project/importlib_metadata) as recommended in the first link. 

Closes #37 