### PR TITLE
further algolia API compatability

### DIFF
--- a/astropylibrarian/algolia/client.py
+++ b/astropylibrarian/algolia/client.py
@@ -82,19 +82,19 @@ class AlgoliaIndex(BaseAlgoliaIndex):
         await self.algolia_client.close()
         self._logger.debug("Finished closing algolia client")
 
-    async def browse_objects_async(
+    async def browse_objects(
         self, browse_params: BrowseParamsObject
     ) -> BrowseResponse:
         return await self.algolia_client.browse_objects(
             index_name=self.name, aggregator=None, browse_params=browse_params
         )
 
-    async def save_objects_async(
+    async def save_objects(
         self, objects: list[dict[str, Any]]
     ) -> list[BatchResponse]:
         return self.algolia_client.save_objects(self.name, objects)
 
-    async def delete_objects_async(self, objectids: list[str]) -> list[BatchResponse]:
+    async def delete_objects(self, objectids: list[str]) -> list[BatchResponse]:
         return self.algolia_client.delete_objects(self.name, objectids)
 
 
@@ -128,17 +128,17 @@ class MockAlgoliaIndex(BaseAlgoliaIndex):
     ) -> None:
         self._logger.debug("Closing MockAlgoliaIndex")
 
-    async def save_objects_async(
+    async def save_objects(
         self,
         objects: list[dict] | Iterator[dict],
         request_options: dict[str, Any] | None = None,
     ) -> "MockMultiResponse":
-        """Mock implementation of save_objects_async."""
+        """Mock implementation of save_objects."""
         for obj in objects:
             self._saved_objects.append(deepcopy(obj))
         return MockMultiResponse()
 
-    async def browse_objects_async(
+    async def browse_objects(
         self, search_settings: dict[str, Any]
     ) -> AsyncIterator[dict[str, Any]]:
         self._logger.debug("Got search settings %s", search_settings)
@@ -148,7 +148,7 @@ class MockAlgoliaIndex(BaseAlgoliaIndex):
         for _ in range(5):
             yield {}
 
-    async def delete_objects_async(
+    async def delete_objects(
         self, objectids: list[str]
     ) -> list[DeletedAtResponse]:
         return [DeletedAtResponse(task_id=0, deleted_at="") for _ in objectids]

--- a/astropylibrarian/workflows/deleterooturl.py
+++ b/astropylibrarian/workflows/deleterooturl.py
@@ -30,7 +30,7 @@ async def delete_root_url(
 
     logger.debug("Found %d objects for deletion", len(object_ids))
 
-    responses = await algolia_index.delete_objects_async(object_ids)
+    responses = await algolia_index.delete_objects(object_ids)
     logger.debug("Algolia response:\n%s", responses)
 
     logger.info("Deleted %d objects", len(object_ids))
@@ -47,5 +47,5 @@ async def search_for_records(
     obj = BrowseParamsObject(
         filters=filters, attributes_to_retrieve=["root_url"], attributes_to_highlight=[]
     )
-    async for result in algolia_index.browse_objects_async(obj):
+    async for result in algolia_index.browse_objects(obj):
         yield result

--- a/astropylibrarian/workflows/expirerecords.py
+++ b/astropylibrarian/workflows/expirerecords.py
@@ -36,7 +36,7 @@ async def expire_old_records(
         attributes_to_highlight=[],
     )
     old_object_ids: List[str] = []
-    async for r in algolia_index.browse_objects_async(obj):
+    async for r in algolia_index.browse_objects(obj):
         # Double check that we're deleting the right things.
         if r["root_url"] != root_url:
             logger.warning("root_url does not match: %s", r["baseUrl"])
@@ -52,7 +52,7 @@ async def expire_old_records(
         root_url,
     )
 
-    await algolia_index.delete_objects_async(old_object_ids)
+    await algolia_index.delete_objects(old_object_ids)
 
     logger.info("Finished deleting expired objects for %s", root_url)
 

--- a/astropylibrarian/workflows/indexjupyterbookpage.py
+++ b/astropylibrarian/workflows/indexjupyterbookpage.py
@@ -42,7 +42,7 @@ async def index_jupyterbook_page(
     logger.debug(
         "Indexing %d records for Jupyter Book page at %s", len(records), url
     )
-    response = await algolia_index.save_objects_async(records)
+    response = await algolia_index.save_objects(records)
     logger.debug("Algolia save_objects: %s", response.raw_responses)
 
     object_ids = [r["objectID"] for r in records]

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -170,7 +170,7 @@ async def index_tutorial(
 
     saved_object_ids: List[str] = []
     try:
-        response = await algolia_index.save_objects_async(records)
+        response = await algolia_index.save_objects(records)
     except RequestException as e:
         logger.error(
             "Error saving objects for tutorial %s:\n%s",


### PR DESCRIPTION
Removes __async_ from relevant function names, e.g., `save_objects_async`, to be compatible with current Algolia API.