### PR TITLE
Pass `object` explicitly to `save_objects` method

### DIFF
--- a/astropylibrarian/workflows/indexjupyterbookpage.py
+++ b/astropylibrarian/workflows/indexjupyterbookpage.py
@@ -42,7 +42,7 @@ async def index_jupyterbook_page(
     logger.debug(
         "Indexing %d records for Jupyter Book page at %s", len(records), url
     )
-    response = await algolia_index.save_objects(records)
+    response = await algolia_index.save_objects(records=records)
     logger.debug("Algolia save_objects: %s", response.raw_responses)
 
     object_ids = [r["objectID"] for r in records]

--- a/astropylibrarian/workflows/indextutorial.py
+++ b/astropylibrarian/workflows/indextutorial.py
@@ -170,7 +170,7 @@ async def index_tutorial(
 
     saved_object_ids: List[str] = []
     try:
-        response = await algolia_index.save_objects(records)
+        response = await algolia_index.save_objects(objects=records)
     except RequestException as e:
         logger.error(
             "Error saving objects for tutorial %s:\n%s",


### PR DESCRIPTION
The algolia `save_objects` method probably just needs to be replaced to be compatible with algolia v4.0+, but this is a quick attempt to keep the method and debug a downstream deployment fail in the `learn_astropy` CI.