### PR TITLE
Attempted fix of learn-astropy workflow failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Mac OS
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/astropylibrarian/workflows/expirerecords.py
+++ b/astropylibrarian/workflows/expirerecords.py
@@ -27,7 +27,7 @@ async def expire_old_records(
     filters = (
         f"root_url:{escape_facet_value(root_url)}"
         " AND NOT "
-        f"root_url:{escape_facet_value(root_url)}"
+        f"index_epoch:{escape_facet_value(index_epoch)}"
     )
 
     obj = BrowseParamsObject(
@@ -36,12 +36,12 @@ async def expire_old_records(
         attributes_to_highlight=[],
     )
     old_object_ids: List[str] = []
-    for r in await algolia_index.browse_objects(obj):
+    async for r in algolia_index.browse_objects(obj):
         # Double check that we're deleting the right things.
         if r["root_url"] != root_url:
-            logger.warning("root_url does not match: %s", r["baseUrl"])
+            logger.warning("root_url does not match: %s", r["root_url"])
             continue
-        if r["surrogateKey"] == index_epoch:
+        if r["index_epoch"] == index_epoch:
             logger.warning("index_epoch matches current epoch: %s", r["index_epoch"])
             continue
         old_object_ids.append(r["objectID"])


### PR DESCRIPTION
The learn-astropy 'deploy' workflow (that updates learn.astropy.org) is failing - it is deploying the site to the gh-pages branch, but failing to subsequently index the site content. The failure is due to errors in this repo in code using algolia, likely at least partially due to compatibility issues after updating the algolia dependency from v3 to v4. 

This is the first of several potential PRs to test whether changes to this repo fix the error in the learn-astropy workflow, as the CI running there is the simplest test of changes here. 